### PR TITLE
Fix fading with fast rotary encoder changes

### DIFF
--- a/LEDOutput.cpp
+++ b/LEDOutput.cpp
@@ -146,6 +146,9 @@ void LEDOutput::setDimStep(int inDimStep){
 
 void LEDOutput::setDimStepUp(){
 	/// Increase the dim level by one, if not already maximum
+	// End an in-progress fade, if needed
+	setDimFadeStop();
+	// Increment the dim level
 	if(__state_dim_level < NUM_DIM_STEPS-1){
 		__state_dim_level++;
 	} 
@@ -158,6 +161,9 @@ void LEDOutput::setDimStepUp(){
 
 void LEDOutput::setDimStepDown(){
 	/// Decrease the dim level by one, if not already zero
+	// End an in-progress fade, if needed
+	setDimFadeStop();
+	// Decrement the dim level
 	if (__state_dim_level > 0){
 		__state_dim_level--;
 	} 

--- a/LEDOutput.h
+++ b/LEDOutput.h
@@ -25,7 +25,7 @@
 #include <math.h>
 
 #define MAX_PWM 255		 // The number of PWM levels, usually 255
-#define NUM_DIM_STEPS 12 // The number of steps on the dimming scale
+#define NUM_DIM_STEPS 7 // The number of steps on the dimming scale
 
 
 class LEDOutput {
@@ -87,7 +87,7 @@ class LEDOutput {
 		int __state_pwm_last = 0;
 		int __sane_pwm;
 		
-		byte __state_fade_pwm_target = 0;
+		int __state_fade_pwm_target = 0;
 		unsigned long __state_fade_end_millis = 0UL;
 		unsigned int __state_fade_duration_millis = 0;
 		unsigned int __state_fade_default_millis = 0;


### PR DESCRIPTION
This change forces the LED output to be updated when changing step during a currently running fade