### PR TITLE
Make fading more smooth

### DIFF
--- a/LEDOutput.cpp
+++ b/LEDOutput.cpp
@@ -129,49 +129,45 @@ void LEDOutput::setDimStep(int inDimStep){
 	/// Set the desired output level, in terms of the dimming step
 	// Check the input is sane, i.e. is between 0 and the maximum step
 	if (inDimStep > NUM_DIM_STEPS-1){
-		__state_dim_level = NUM_DIM_STEPS-1;
+		__state_dim_level_goal = NUM_DIM_STEPS-1;
 	} 
 	else if (inDimStep < 0){
-		__state_dim_level = 0;
+		__state_dim_level_goal = 0;
 	}
 	else {
-		__state_dim_level = inDimStep;
+		__state_dim_level_goal = inDimStep;
 	}
+	__state_dim_level_goal = __state_dim_level;
 	// Set the PWM to the value corresponding to this dim level
-	setDimPWM(pwm_dim_levels[__state_dim_level]);
-	// Note that setDimPWM() will set __state_dim_level again by
-	// re-calculating the closest dim level - even though we just 
-	// specified it, but this doesn't really matter
+	setDimPWM(pwm_dim_levels[__state_dim_level_goal]);
+	// Note that setDimPWM() will set __state_dim_level by
+	// calculating the closest dim level during the fade event
 }
 
 void LEDOutput::setDimStepUp(){
 	/// Increase the dim level by one, if not already maximum
-	// End an in-progress fade, if needed
-	setDimFadeStop();
-	// Increment the dim level
-	if(__state_dim_level < NUM_DIM_STEPS-1){
-		__state_dim_level++;
+	// Increment the dim level goal 
+	if(__state_dim_level_goal < NUM_DIM_STEPS-1){
+		__state_dim_level_goal++;
 	} 
 	else {
-		__state_dim_level = NUM_DIM_STEPS-1;
+		__state_dim_level_goal = NUM_DIM_STEPS-1;
 	}
 	// Set the PWM to the value corresponding to this dim level
-	setDimPWM(pwm_dim_levels[__state_dim_level]);
+	setDimPWM(pwm_dim_levels[__state_dim_level_goal]);
 }
 
 void LEDOutput::setDimStepDown(){
 	/// Decrease the dim level by one, if not already zero
-	// End an in-progress fade, if needed
-	setDimFadeStop();
-	// Decrement the dim level
-	if (__state_dim_level > 0){
-		__state_dim_level--;
+	// Decrement the dim level goal
+	if (__state_dim_level_goal > 0){
+		__state_dim_level_goal--;
 	} 
 	else {
-		__state_dim_level = 0;
+		__state_dim_level_goal = 0;
 	}
 	// Set the PWM to the value corresponding to this dim level
-	setDimPWM(pwm_dim_levels[__state_dim_level]);
+	setDimPWM(pwm_dim_levels[__state_dim_level_goal]);
 }
 
 void LEDOutput::setDimPercent(int inDimPercent){

--- a/LEDOutput.cpp
+++ b/LEDOutput.cpp
@@ -257,7 +257,11 @@ void LEDOutput::setDimFadeStop(){
 
 void LEDOutput::setDimDefaultFade(int inTimeMillis){
 	/// Set the default fade duration
-	__state_fade_default_millis = abs(inTimeMillis);
+	if (abs(inTimeMillis) > 255){
+		__state_fade_default_millis = 255;
+	} else {
+		__state_fade_default_millis = abs(inTimeMillis);
+	}
 }
 
 int LEDOutput::getDimPWM(){

--- a/LEDOutput.cpp
+++ b/LEDOutput.cpp
@@ -137,7 +137,6 @@ void LEDOutput::setDimStep(int inDimStep){
 	else {
 		__state_dim_level_goal = inDimStep;
 	}
-	__state_dim_level_goal = __state_dim_level;
 	// Set the PWM to the value corresponding to this dim level
 	setDimPWM(pwm_dim_levels[__state_dim_level_goal]);
 	// Note that setDimPWM() will set __state_dim_level by

--- a/LEDOutput.h
+++ b/LEDOutput.h
@@ -78,20 +78,19 @@ class LEDOutput {
 		bool getPowerOn();
 		
 	private:
-		byte led_pin;
+		unsigned short led_pin;
 		int pwm_dim_levels[NUM_DIM_STEPS];
-		byte __state_dim_level = 0;
-		byte __state_dim_level_goal = 0;
+		unsigned short __state_dim_level = 0;
+		unsigned short __state_dim_level_goal = 0;
 		bool __state_power_on = false;
-		byte __state_percent = 0;
+		unsigned short __state_percent = 0;
 		int __state_pwm = 0;
 		int __state_pwm_last = 0;
 		int __sane_pwm;
 		
 		int __state_fade_pwm_target = 0;
 		unsigned long __state_fade_end_millis = 0UL;
-		unsigned int __state_fade_duration_millis = 0;
-		unsigned int __state_fade_default_millis = 0;
+		unsigned short __state_fade_default_millis = 0;
 		float __state_fade_pwmconst = 0.00;
 		bool __state_fade_inprogress = false;
 		

--- a/LEDOutput.h
+++ b/LEDOutput.h
@@ -81,6 +81,7 @@ class LEDOutput {
 		byte led_pin;
 		int pwm_dim_levels[NUM_DIM_STEPS];
 		byte __state_dim_level = 0;
+		byte __state_dim_level_goal = 0;
 		bool __state_power_on = false;
 		byte __state_percent = 0;
 		int __state_pwm = 0;


### PR DESCRIPTION
Fixed jumps in dim steps when changing step faster than the fade time (i.e. when turning the rotary encoder quickly). Also tidy up some data types. 