### PR TITLE
Add lockout timer when stepping to maximum or minimum dim step, refactor and refine variable types

### DIFF
--- a/LEDOutput.cpp
+++ b/LEDOutput.cpp
@@ -145,28 +145,72 @@ void LEDOutput::setDimStep(int inDimStep){
 
 void LEDOutput::setDimStepUp(){
 	/// Increase the dim level by one, if not already maximum
-	// Increment the dim level goal 
-	if(__state_dim_level_goal < NUM_DIM_STEPS-1){
-		__state_dim_level_goal++;
-	} 
-	else {
-		__state_dim_level_goal = NUM_DIM_STEPS-1;
+	switch (__state_dim_level_goal){
+		case NUM_DIM_STEPS-1: 
+		{
+			// Do nothing, already at maximum 
+			break;
+		}
+		case NUM_DIM_STEPS-2:
+		{
+			// Test if lockout should apply 
+			if (millis() > __state_lockout_end_millis){
+				// Lockout is over, increment dim step 
+				__state_dim_level_goal++; 
+				// Set the PWM to the value corresponding to this dim level
+				setDimPWM(pwm_dim_levels[__state_dim_level_goal]);
+			} else {
+				// Lockout still applies, reset counter
+				__state_lockout_end_millis = millis() + __state_step_lockout_millis; 
+			}
+			break;
+		}
+		default:
+		{
+			// Increase dim step 
+			__state_dim_level_goal++;
+			// Store the end time for dim step lockout
+			__state_lockout_end_millis = millis() + __state_step_lockout_millis; 
+			// Set the PWM to the value corresponding to this dim level
+			setDimPWM(pwm_dim_levels[__state_dim_level_goal]);
+			break;
+		}
 	}
-	// Set the PWM to the value corresponding to this dim level
-	setDimPWM(pwm_dim_levels[__state_dim_level_goal]);
 }
 
 void LEDOutput::setDimStepDown(){
 	/// Decrease the dim level by one, if not already zero
-	// Decrement the dim level goal
-	if (__state_dim_level_goal > 0){
-		__state_dim_level_goal--;
-	} 
-	else {
-		__state_dim_level_goal = 0;
+	switch (__state_dim_level_goal){
+		case 0: 
+		{
+			// Do nothing, already at minimum 
+			break;
+		}
+		case 1:
+		{
+			// Test if lockout should apply 
+			if (millis() > __state_lockout_end_millis){
+				// Lockout is over, decrement dim step 
+				__state_dim_level_goal--; 
+				// Set the PWM to the value corresponding to this dim level
+				setDimPWM(pwm_dim_levels[__state_dim_level_goal]);
+			} else {
+				// Lockout still applies, reset counter
+				__state_lockout_end_millis = millis() + __state_step_lockout_millis; 
+			}
+			break;
+		}
+		default:
+		{
+			// Decrease dim step 
+			__state_dim_level_goal--;
+			// Store the end time for dim step lockout
+			__state_lockout_end_millis = millis() + __state_step_lockout_millis; 
+			// Set the PWM to the value corresponding to this dim level
+			setDimPWM(pwm_dim_levels[__state_dim_level_goal]);
+			break;
+		}
 	}
-	// Set the PWM to the value corresponding to this dim level
-	setDimPWM(pwm_dim_levels[__state_dim_level_goal]);
 }
 
 void LEDOutput::setDimPercent(int inDimPercent){
@@ -260,6 +304,15 @@ void LEDOutput::setDimDefaultFade(int inTimeMillis){
 		__state_fade_default_millis = 255;
 	} else {
 		__state_fade_default_millis = abs(inTimeMillis);
+	}
+}
+
+void LEDOutput::setDimStepLockout(int inTimeMillis){
+	/// Set the dim step lockout time 
+	if (abs(inTimeMillis) > 255){
+		__state_step_lockout_millis = 255;
+	} else {
+		__state_step_lockout_millis = abs(inTimeMillis);
 	}
 }
 

--- a/LEDOutput.cpp
+++ b/LEDOutput.cpp
@@ -49,7 +49,7 @@ void LEDOutput::process(){
 	/// Update the LED output
 	// First, process any ongoing fade event
 	if (__state_fade_inprogress){
-		unsigned long millis_now = millis();
+		uint32_t millis_now = millis();
 		// If we have passed the end time, set the output to the target value
 		if (millis_now > __state_fade_end_millis){
 			setDimPWMExact(__state_fade_pwm_target);
@@ -316,7 +316,7 @@ void LEDOutput::setDimStepLockout(int inTimeMillis){
 	}
 }
 
-int LEDOutput::getDimPWM(){
+uint16_t LEDOutput::getDimPWM(){
 	if (__state_power_on){
 		return __state_pwm;
 	} 
@@ -359,7 +359,7 @@ void LEDOutput::setStatusCallback(void (*cb)(void)){
 
 
 // Private methods
-int LEDOutput::__find_closest_step(int inPWM){
+uint8_t LEDOutput::__find_closest_step(int inPWM){
 	/// Find the nearest PWM step to the given input
 	int closest_step = 0;
 	__sane_pwm = __sane_in_pwm(inPWM);
@@ -372,7 +372,7 @@ int LEDOutput::__find_closest_step(int inPWM){
 	return closest_step;
 }
 
-int LEDOutput::__sane_in_pwm(int inPWM){
+uint16_t LEDOutput::__sane_in_pwm(int inPWM){
 	/// Checking sanity of input PWM value is done often, so it gets a function
 	if (inPWM > MAX_PWM){
 		__sane_pwm = MAX_PWM;

--- a/LEDOutput.cpp
+++ b/LEDOutput.cpp
@@ -325,7 +325,7 @@ int LEDOutput::getDimPWM(){
 	}
 }
 
-int LEDOutput::getDimPercent(){
+uint8_t LEDOutput::getDimPercent(){
 	if (__state_power_on){
 		return __state_percent;
 	} 
@@ -334,7 +334,7 @@ int LEDOutput::getDimPercent(){
 	}
 }
 
-int LEDOutput::getDimStep(){
+uint8_t LEDOutput::getDimStep(){
 	if (__state_power_on){
 		return __state_dim_level;
 	} 
@@ -343,7 +343,7 @@ int LEDOutput::getDimStep(){
 	}
 }
 
-unsigned int LEDOutput::getDimDefaultFade(){
+uint8_t LEDOutput::getDimDefaultFade(){
 	return __state_fade_default_millis;
 }
 

--- a/LEDOutput.cpp
+++ b/LEDOutput.cpp
@@ -21,7 +21,7 @@
 #include "LEDOutput.h"
 
 
-LEDOutput::LEDOutput(int inLEDPin){
+LEDOutput::LEDOutput(uint8_t inLEDPin){
 	/// Initialise a dimmable LED
 	led_pin = inLEDPin;
 	analogWrite(led_pin, 0);
@@ -125,7 +125,7 @@ void LEDOutput::setPowerOff(){
 	__state_power_on = false;
 }
 
-void LEDOutput::setDimStep(int inDimStep){
+void LEDOutput::setDimStep(uint8_t inDimStep){
 	/// Set the desired output level, in terms of the dimming step
 	// Check the input is sane, i.e. is between 0 and the maximum step
 	if (inDimStep > NUM_DIM_STEPS-1){
@@ -213,7 +213,7 @@ void LEDOutput::setDimStepDown(){
 	}
 }
 
-void LEDOutput::setDimPercent(int inDimPercent){
+void LEDOutput::setDimPercent(uint8_t inDimPercent){
 	/// Set the desired output level; in terms of a percentage
 	byte percent;
 	int pwm;
@@ -233,7 +233,7 @@ void LEDOutput::setDimPercent(int inDimPercent){
 	setDimPWM(pwm);
 }
 
-void LEDOutput::setDimPWM(int inPWM){
+void LEDOutput::setDimPWM(uint16_t inPWM){
 	/// Set the desired output level; in terms of the PWM level (i.e. 0-255)
 	/// This will round up to the nearest step
 	__sane_pwm = __sane_in_pwm(inPWM);
@@ -248,7 +248,7 @@ void LEDOutput::setDimPWM(int inPWM){
 	}
 }
 
-void LEDOutput::setDimPWMExact(int inPWM){
+void LEDOutput::setDimPWMExact(uint16_t inPWM){
 	/// Set the desired output level; in terms of the PWM level (i.e. 0-255)
 	/// This function should be the only one used to change the output, 
 	/// it will also update the percent and step state values
@@ -272,7 +272,7 @@ void LEDOutput::setDimPWMExact(int inPWM){
 	#endif
 }
 
-void LEDOutput::setDimFadeStart(int inTargetPWM, int inTimeMillis){
+void LEDOutput::setDimFadeStart(uint16_t inTargetPWM, uint16_t inTimeMillis){
 	/// Start fading down to the given target PWM level, over a timespan
 	/// of the given number of milliseconds
 	// Make sure input time is not negative
@@ -298,22 +298,14 @@ void LEDOutput::setDimFadeStop(){
 	}
 }
 
-void LEDOutput::setDimDefaultFade(int inTimeMillis){
+void LEDOutput::setDimDefaultFade(uint8_t inTimeMillis){
 	/// Set the default fade duration
-	if (abs(inTimeMillis) > 255){
-		__state_fade_default_millis = 255;
-	} else {
-		__state_fade_default_millis = abs(inTimeMillis);
-	}
+	__state_fade_default_millis = inTimeMillis;
 }
 
-void LEDOutput::setDimStepLockout(int inTimeMillis){
+void LEDOutput::setDimStepLockout(uint8_t inTimeMillis){
 	/// Set the dim step lockout time 
-	if (abs(inTimeMillis) > 255){
-		__state_step_lockout_millis = 255;
-	} else {
-		__state_step_lockout_millis = abs(inTimeMillis);
-	}
+	__state_step_lockout_millis = inTimeMillis;
 }
 
 uint16_t LEDOutput::getDimPWM(){
@@ -359,7 +351,7 @@ void LEDOutput::setStatusCallback(void (*cb)(void)){
 
 
 // Private methods
-uint8_t LEDOutput::__find_closest_step(int inPWM){
+uint8_t LEDOutput::__find_closest_step(uint16_t inPWM){
 	/// Find the nearest PWM step to the given input
 	int closest_step = 0;
 	__sane_pwm = __sane_in_pwm(inPWM);
@@ -372,7 +364,7 @@ uint8_t LEDOutput::__find_closest_step(int inPWM){
 	return closest_step;
 }
 
-uint16_t LEDOutput::__sane_in_pwm(int inPWM){
+uint16_t LEDOutput::__sane_in_pwm(uint16_t inPWM){
 	/// Checking sanity of input PWM value is done often, so it gets a function
 	if (inPWM > MAX_PWM){
 		__sane_pwm = MAX_PWM;

--- a/LEDOutput.h
+++ b/LEDOutput.h
@@ -74,7 +74,7 @@ class LEDOutput {
 		
 		
 		// A bunch of get methods to access the internal state variables
-		int getDimPWM();
+		uint16_t getDimPWM();
 		uint8_t getDimPercent();
 		uint8_t getDimStep();
 		uint8_t getDimDefaultFade();
@@ -82,27 +82,27 @@ class LEDOutput {
 		
 	private:
 		uint8_t led_pin;
-		int pwm_dim_levels[NUM_DIM_STEPS];
+		uint16_t pwm_dim_levels[NUM_DIM_STEPS];
 		uint8_t __state_dim_level = 0;
 		uint8_t __state_dim_level_goal = 0;
 		bool __state_power_on = false;
 		uint8_t __state_percent = 0;
-		int __state_pwm = 0;
-		int __state_pwm_last = 0;
-		int __sane_pwm;
+		int16_t __state_pwm = 0;
+		int16_t __state_pwm_last = 0;
+		int16_t __sane_pwm;
 		
-		int __state_fade_pwm_target = 0;
-		unsigned long __state_fade_end_millis = 0UL;
+		int16_t __state_fade_pwm_target = 0;
+		uint32_t __state_fade_end_millis = 0UL;
 		uint8_t __state_fade_default_millis = 0;
 		uint8_t __state_step_lockout_millis = 0;
-		unsigned long __state_lockout_end_millis = 0UL;
+		uint32_t __state_lockout_end_millis = 0UL;
 		float __state_fade_pwmconst = 0.00;
 		bool __state_fade_inprogress = false;
 		
 		bool __status_update_needed = false;
 		
-		int __find_closest_step(int inPWM);
-		int __sane_in_pwm(int inPWM);
+		uint8_t __find_closest_step(int inPWM);
+		uint16_t __sane_in_pwm(int inPWM);
 		
 		void (*__status_callback)(void);
 		bool __status_callback_exists = false;

--- a/LEDOutput.h
+++ b/LEDOutput.h
@@ -66,6 +66,9 @@ class LEDOutput {
 		// Set the default fade duration, used when changing PWM output
 		void setDimDefaultFade(int inTimeMillis);
 		
+		// Set the step up/down power off lockout time
+		void setDimStepLockout(int inTimeMillis);
+		
 		// Set status update callback. Will be called when LED status changes. 
 		void setStatusCallback(void (*cb)(void));
 		
@@ -91,6 +94,8 @@ class LEDOutput {
 		int __state_fade_pwm_target = 0;
 		unsigned long __state_fade_end_millis = 0UL;
 		unsigned short __state_fade_default_millis = 0;
+		uint8_t __state_step_lockout_millis = 0;
+		unsigned long __state_lockout_end_millis = 0UL;
 		float __state_fade_pwmconst = 0.00;
 		bool __state_fade_inprogress = false;
 		

--- a/LEDOutput.h
+++ b/LEDOutput.h
@@ -31,7 +31,7 @@
 class LEDOutput {
 	public:
 		// Create an LED output controller for the given pin
-		LEDOutput(int inLEDPin);
+		LEDOutput(uint8_t inLEDPin);
 		
 		// Run in each cycle of the main loop, to update the LED output
 		void process();
@@ -42,32 +42,32 @@ class LEDOutput {
 		void setPowerOff(); // Directly turn off
 		
 		// Set the desired output level, in terms of the dimming step
-		void setDimStep(int inDimStep);
+		void setDimStep(uint8_t inDimStep);
 		
 		// Step up or down to the next brightness step
 		void setDimStepUp();
 		void setDimStepDown();
 		
 		// Set the desired output level; in terms of a percentage (rounds up to nearest step)
-		void setDimPercent(int inDimPercent);
+		void setDimPercent(uint8_t inDimPercent);
 		
 		// Set the desired output level; in terms of the PWM level (i.e. 0-255) (rounds up to nearest step)
-		void setDimPWM(int inPWM);
+		void setDimPWM(uint16_t inPWM);
 		
 		// Set the desired output level; in terms of the PWM level (i.e. 0-255) (no rounding)
-		void setDimPWMExact(int inPWM);
+		void setDimPWMExact(uint16_t inPWM);
 		
 		// Begin fading PWM level over specified duration
-		void setDimFadeStart(int inTargetPWM, int inTimeMillis);
+		void setDimFadeStart(uint16_t inTargetPWM, uint16_t inTimeMillis);
 		
 		// Stop fading, and jump straight to target PWM state
 		void setDimFadeStop(); 
 		
 		// Set the default fade duration, used when changing PWM output
-		void setDimDefaultFade(int inTimeMillis);
+		void setDimDefaultFade(uint8_t inTimeMillis);
 		
 		// Set the step up/down power off lockout time
-		void setDimStepLockout(int inTimeMillis);
+		void setDimStepLockout(uint8_t inTimeMillis);
 		
 		// Set status update callback. Will be called when LED status changes. 
 		void setStatusCallback(void (*cb)(void));
@@ -101,8 +101,8 @@ class LEDOutput {
 		
 		bool __status_update_needed = false;
 		
-		uint8_t __find_closest_step(int inPWM);
-		uint16_t __sane_in_pwm(int inPWM);
+		uint8_t __find_closest_step(uint16_t inPWM);
+		uint16_t __sane_in_pwm(uint16_t inPWM);
 		
 		void (*__status_callback)(void);
 		bool __status_callback_exists = false;

--- a/LEDOutput.h
+++ b/LEDOutput.h
@@ -75,25 +75,25 @@ class LEDOutput {
 		
 		// A bunch of get methods to access the internal state variables
 		int getDimPWM();
-		int getDimPercent();
-		int getDimStep();
-		unsigned int getDimDefaultFade();
+		uint8_t getDimPercent();
+		uint8_t getDimStep();
+		uint8_t getDimDefaultFade();
 		bool getPowerOn();
 		
 	private:
-		unsigned short led_pin;
+		uint8_t led_pin;
 		int pwm_dim_levels[NUM_DIM_STEPS];
-		unsigned short __state_dim_level = 0;
-		unsigned short __state_dim_level_goal = 0;
+		uint8_t __state_dim_level = 0;
+		uint8_t __state_dim_level_goal = 0;
 		bool __state_power_on = false;
-		unsigned short __state_percent = 0;
+		uint8_t __state_percent = 0;
 		int __state_pwm = 0;
 		int __state_pwm_last = 0;
 		int __sane_pwm;
 		
 		int __state_fade_pwm_target = 0;
 		unsigned long __state_fade_end_millis = 0UL;
-		unsigned short __state_fade_default_millis = 0;
+		uint8_t __state_fade_default_millis = 0;
 		uint8_t __state_step_lockout_millis = 0;
 		unsigned long __state_lockout_end_millis = 0UL;
 		float __state_fade_pwmconst = 0.00;


### PR DESCRIPTION
Add timer lockout feature, so when stepping up or down rapidly with `setDimStepUp()` and `setDimStepDown()`, the LED won't go to maximum or to zero without first stopping and enforcing a wait time. 

Also refine some variable types and re-factor code where needed because of this. 