### PR TITLE
Remove standby PWM level storge, it is unnecessary

### DIFF
--- a/LEDOutput.cpp
+++ b/LEDOutput.cpp
@@ -257,6 +257,8 @@ void LEDOutput::setDimFadeStart(uint16_t inTargetPWM, uint16_t inTimeMillis){
 	/// of the given number of milliseconds
 	// Store the target PWM value (after sanitising it)
 	__state_fade_pwm_target = __sane_in_pwm(inTargetPWM);
+	// Also update the target dim level
+	__state_dim_level_goal = __find_closest_step(__state_fade_pwm_target);
 	// Check we are not fading for zero duration
 	if (inTimeMillis == 0) {
 		// Set the output without fading 

--- a/LEDOutput.cpp
+++ b/LEDOutput.cpp
@@ -63,7 +63,7 @@ void LEDOutput::process(){
 			// Calculate how many millis we have left to fade for
 			float millis_remain = __state_fade_end_millis - __millis_now;
 			// Calculate which PWM step we should be at
-			byte pwm_delta = __state_fade_pwm_target - int(millis_remain * __state_fade_pwmconst);
+			uint16_t pwm_delta = __state_fade_pwm_target - int(millis_remain * __state_fade_pwmconst);
 			// Set the output to that value
 			setDimPWMExact(pwm_delta);
 		}
@@ -98,30 +98,6 @@ void LEDOutput::process(){
 		}
 		__status_update_needed = false;
 	}
-}
-
-void LEDOutput::setPowerOn(bool inPower){
-	/// Turn the LED on or off 
-	if (inPower){
-		// Restore the standby PWM level
-		setDimFadeStart(__state_pwm_standby, __state_fade_default_millis);
-	} 
-	else {
-		// Store the current PWM level when turning off 
-		__state_pwm_standby = __state_fade_pwm_target;
-		// Then set the output to 0, fading if enabled 
-		setDimFadeStart(0, __state_fade_default_millis);
-	}
-}
-
-void LEDOutput::setPowerOn(){
-	/// Directly set the power to be "on"
-	setPowerOn(true);
-}
-
-void LEDOutput::setPowerOff(){
-	/// Directly set the power to be "off"
-	setPowerOn(false);
 }
 
 void LEDOutput::setDimStep(uint8_t inDimStep){

--- a/LEDOutput.h
+++ b/LEDOutput.h
@@ -36,11 +36,6 @@ class LEDOutput {
 		// Run in each cycle of the main loop, to update the LED output
 		void process();
 		
-		// Turn the LED on or off
-		void setPowerOn(bool inPower);
-		void setPowerOn();  // Directly turn on
-		void setPowerOff(); // Directly turn off
-		
 		// Set the desired output level, in terms of the dimming step
 		void setDimStep(uint8_t inDimStep);
 		
@@ -92,7 +87,6 @@ class LEDOutput {
 		uint8_t __state_percent = 0;
 		int16_t __state_pwm = 0;
 		int16_t __state_pwm_last = 0;
-		int16_t __state_pwm_standby = 0;
 		int16_t __sane_pwm;
 		
 		int16_t __state_fade_pwm_target = 0;

--- a/docs/LEDOutput.md
+++ b/docs/LEDOutput.md
@@ -13,6 +13,7 @@ This provides a more even perception of brightness change between each step than
 * Discrete dimming steps, using an exponential function to determine the PWM level for each step 
 * Support for smoothly fading to a new PWM output level
 * Support for a status callback, called when a fade is complete 
+* Ability to set an automatic power off timer 
 
 ## Usage 
 
@@ -35,10 +36,6 @@ void loop() {
 ### `process()`
 
 Must be called frequently in the main loop to update the output PWM value. 
-
-### `setPowerOn()` and `setPowerOff()`
-
-Sets the output on or off. Can be called without an argument, or as `setPowerOn(true)` or `setPowerOn(false)`. 
 
 ### `setDimStep(inDimStep)`
 
@@ -65,6 +62,10 @@ Set the LED output to the specified PWM, i.e. 0-255 (if using 8 bit PWM). Simila
 ### `setDimFadeStart(inTargetPWM, inTimeMillis)`
 
 Start fading the LED output to the specified PWM level, over the specifed number of milliseconds. 
+
+### `setAutoOffTimer(inTimeMillis);`
+
+Set the LED to turn off after a delay of the specified number of milliseconds. 
 
 ### `setDimFadeStop()`
 


### PR DESCRIPTION
This change will remove the "standby" PWM level. This will slightly simplify usage of the `LEDOutput` class, now it is only necessary to use a `setDim` method. The `setPower` methods have been removed. 
This will close #17. 

Also fixes a small bug with the dim step goal not being set when using `setDimFadeStart`